### PR TITLE
Exclude kubo/kubelet by default when deploying the cluster tile

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -419,6 +419,9 @@ runtime_configs:
           - os: ubuntu-xenial
           - os: ubuntu-trusty
           - os: centos-7
+        exclude:
+          jobs:
+          - kubo
         jobs:
         - name: dd-agent
           release: datadog-agent

--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -421,7 +421,8 @@ runtime_configs:
           - os: centos-7
         exclude:
           jobs:
-          - kubo
+          - name: kubelet
+            release: kubo
         jobs:
         - name: dd-agent
           release: datadog-agent


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.

### What does this PR do?

This PR adds a job exclusion rule to the cluster monitoring tile. We now exclude the bosh agent from deploying on VMs where the `kubelet` job from the `kubo` release is running. 

### Description of the Change

This allows the cluster monitoring tile to be installed in PKS environments. 

We currently recommend using our PKS integration (kubernetes install of the Datadog agent) to monitor your PKS worker VMs - https://docs.datadoghq.com/integrations/pivotal_pks/#setup. 

Adding this exclusion rule means we won't duplicate the Datadog Agent being on the worker node while allowing us to monitor the other VMS in a PKS environment. 

Note for OpsMan + PKS (NO PAS):
The nozzle depends on PAS to be able to be deployed, otherwise this tile will fail. However, you can set the number of instances on the nozzle to `0` in the `Resource Config` section of the cluster tile to let only the bosh agent deploy. 

### Possible Drawbacks

This will limit the bosh agent (when deployed via the tile) from landing on any VM with the kubo-kubelet job on it. There could be scenarios where we'd like the Agent to be there, but it'd be bad to have multiple agents on a single host. 

### Verification Process

Got access to a PKS environment with 3 workers and 1 master VM. I ran a deploy of this tile, and as expected the Agent appeared on only the master VM. 

### Additional Notes

Docs reference for exclusion rule - https://bosh.io/docs/runtime-config/#placement-rules

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
