### PR TITLE
Revert "Add option to send application environment variables as custom container tags"

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -498,15 +498,6 @@ forms:
         label: List of events to collect
         default: audit.app.restage,audit.app.update,audit.app.create,app.crash
         description: Comma separated list of Cloud Foundry audit events to collect.
-      - name: cloud_foundry_bbs_env_include
-        type: string_list
-        label: Application environment variables include patterns
-        optional: true
-        description: List of regular expressions to allow a set of environment variables to be included as container tags.
-      - name: cloud_foundry_bbs_env_exclude
-        type: string_list
-        label: Application environment variables exclude patterns
-        description: List of regular expressions to forbid a set of environment variables to be included as container tags.
 
 - name: cf-config
   label: Cloud Foundry Settings
@@ -637,9 +628,6 @@ packages:
         https_proxy: (( .properties.https_proxy_url.value ))
         http_proxy: (( .properties.http_proxy_url.value ))
         no_proxy: (( .properties.no_proxy.parsed_strings ))
-      cloud_foundry_bbs:
-        env_include: (( .properties.cluster_agent_enabled.enabled_option.cloud_foundry_bbs_env_include.parsed_strings))
-        env_exclude: (( .properties.cluster_agent_enabled.enabled_option.cloud_foundry_bbs_env_exclude.parsed_strings))
 
 - name: datadog-agent-boshrelease
   type: bosh-release


### PR DESCRIPTION
Reverts DataDog/datadog-cluster-monitoring-pivotal-tile#40

Need to remove for next release that doesn't have the feature yet.
Plus it's broken so will need to fix