### PR TITLE
Add `refresh_on_cache_miss`, `sidecars_tags` and `isolation_segments_tags` properties to the cluster agent

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -572,6 +572,12 @@ forms:
         label: Enable Isolation Segments tags
         default: false
         description: Whether or not to collect extra tags such as `segment_id` and `segment_name` for containers.
+      - name: cluster_agent_refresh_on_cache_miss
+        configurable: true
+        type: boolean
+        label: Enable refresh on cache miss
+        default: false
+        description: Whether or not to query the CAPI on cache miss in the cluster agent.
       - name: enable_cloud_foundry_api_apps_polling
         configurable: true
         type: boolean
@@ -949,6 +955,7 @@ packages:
         advanced_tagging: (( .properties.cluster_agent_enabled.enabled_option.cluster_agent_advanced_tagging.value ))
         sidecars_tags: (( .properties.cluster_agent_enabled.enabled_option.cluster_agent_sidecars_tags.value ))
         isolation_segments_tags: (( .properties.cluster_agent_enabled.enabled_option.cluster_agent_isolation_segments_tags.value ))
+        refresh_on_cache_miss: (( .properties.cluster_agent_enabled.enabled_option.cluster_agent_refresh_on_cache_miss.value ))
       cloud_foundry_api:
         api_url: https://api.(( ..cf.cloud_controller.system_domain.value ))
         poll_interval: (( .properties.cluster_agent_enabled.enabled_option.cloud_foundry_api_poll_interval.value ))

--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -559,7 +559,19 @@ forms:
         type: boolean
         label: Enable Advanced Tagging
         default: false
+        description: Whether or not to collect all extra tags (sidecars, isolation segments) for containers.
+      - name: cluster_agent_sidecars_tags
+        configurable: true
+        type: boolean
+        label: Enable Sidecars tags
+        default: false
         description: Whether or not to collect extra tags such as `sidecar_present` and `sidecar_count` for containers.
+      - name: cluster_agent_isolation_segments_tags
+        configurable: true
+        type: boolean
+        label: Enable Isolation Segments tags
+        default: false
+        description: Whether or not to collect extra tags such as `segment_id` and `segment_name` for containers.
       - name: enable_cloud_foundry_api_apps_polling
         configurable: true
         type: boolean
@@ -935,6 +947,8 @@ packages:
         enable_cloud_foundry_api_apps_polling: (( .properties.cluster_agent_enabled.enabled_option.enable_cloud_foundry_api_apps_polling.value ))
         serve_nozzle_data: (( .properties.cluster_agent_enabled.enabled_option.cluster_agent_serve_nozzle_data.value ))
         advanced_tagging: (( .properties.cluster_agent_enabled.enabled_option.cluster_agent_advanced_tagging.value ))
+        sidecars_tags: (( .properties.cluster_agent_enabled.enabled_option.cluster_agent_sidecars_tags.value ))
+        isolation_segments_tags: (( .properties.cluster_agent_enabled.enabled_option.cluster_agent_isolation_segments_tags.value ))
       cloud_foundry_api:
         api_url: https://api.(( ..cf.cloud_controller.system_domain.value ))
         poll_interval: (( .properties.cluster_agent_enabled.enabled_option.cloud_foundry_api_poll_interval.value ))


### PR DESCRIPTION
Adds new properties from the cluster agent BOSH release.
See https://github.com/DataDog/datadog-cluster-agent-boshrelease/pull/44 .