### PR TITLE
Pass `api_key` to the cluster agent to add support for the flare command

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -918,6 +918,7 @@ packages:
     instances: 1
     properties:
       cluster_agent:
+        api_key: (( .properties.api_key.value ))
         force_tls_12: (( .properties.force_tls_12.value ))
         bbs_url: (( .properties.cluster_agent_enabled.enabled_option.cluster_agent_bbs_url.value ))
         locket_api_location: (( .properties.cluster_agent_enabled.enabled_option.cluster_agent_locket_api.value ))


### PR DESCRIPTION
Passes the API key to the cluster agent, it is required to send a flare to Datadog.