### PR TITLE
Add options for the `container_tagger` properties

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -428,6 +428,21 @@ forms:
     type: integer
     default: 10
     description: How often to poll the Datadog Cluster Agent for new integration configurations (in seconds).
+  - name: container_tagger_retry_interval
+    label: Datadog Agent Container Tagger retry interval
+    type: integer
+    default: 20
+    description: How often the Datadog Agent tries to inject metadata tags in a Container.
+  - name: container_tagger_retry_count
+    label: Datadog Agent Container Tagger retry count
+    type: integer
+    default: 20
+    description: How many attempts the Datadog Agent tries to inject metadata tags in a Container.
+  - name: container_tagger_shell_path
+    label: Datadog Agent Container Tagger shell path
+    type: string
+    default: "/bin/sh"
+    description: Path to the shell to use to run the update container tags script.
 
 - name: disk-check-config
   label: Disk integration configuration
@@ -1082,6 +1097,10 @@ runtime_configs:
           port: (( .properties.cluster_agent_enabled.enabled_option.cluster_agent_port.value ))
           enabled: (( .properties.cluster_agent_enabled.selected_option.parsed_manifest(cluster_agent_enabled) ))
           address: datadog-cluster-agent.(( ..datadog.deployment_name ))
+        container_tagger:
+          retry_interval: (( .properties.container_tagger_retry_interval.value ))
+          retry_count: (( .properties.container_tagger_retry_count.value ))
+          shell_path: (( .properties.container_tagger_shell_path.value ))
 
 - name: datadog-agent-kube-control-plan
   runtime_config:


### PR DESCRIPTION
Add options to support the following properties in the datadog agent:

```
cloud_foundry_container_tagger:
    retry_interval: 20
    retry_count: 20
    shell_path: /bin/sh
```

See Agent BOSH Release [properties](https://github.com/DataDog/datadog-agent-boshrelease/blob/master/jobs/dd-agent/spec#L289-L297).