### PR TITLE
Fix optional property with default value error

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -522,7 +522,6 @@ forms:
         type: string
         label: Memory limit for the agent process under BPM.
         default: ""
-        optional: true
         description: The memory limit to apply to the agent. It is formatted as a number and then a single character for units e.g. 1G, 256M.
       - name: bpm_agent_open_files
         configurable: true
@@ -541,7 +540,6 @@ forms:
         type: string
         label: Memory limit for the process-agent process under BPM.
         default: ""
-        optional: true
         description: The memory limit to apply to the process-agent. It is formatted as a number and then a single character for units e.g. 1G, 256M.
       - name: bpm_process_agent_open_files
         configurable: true
@@ -560,7 +558,6 @@ forms:
         type: string
         label: Memory limit for the trace-agent process under BPM.
         default: ""
-        optional: true
         description: The memory limit to apply to the trace-agent. It is formatted as a number and then a single character for units e.g. 1G, 256M.
       - name: bpm_trace_agent_open_files
         configurable: true
@@ -579,7 +576,6 @@ forms:
         type: string
         label: Memory limit for the system-probe process under BPM.
         default: ""
-        optional: true
         description: The memory limit to apply to the system-probe. It is formatted as a number and then a single character for units e.g. 1G, 256M.
       - name: bpm_system_probe_open_files
         configurable: true


### PR DESCRIPTION
This PR fixes a bug encountered in OpsManager 2.10, OpsManager displays an error about property_blueprints properties that are marked optional and have a default value simultaneously. 