### PR TITLE
Fix `datadog-bpm` job placement rules

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -1275,8 +1275,21 @@ runtime_configs:
           system_probe.processes: (( .properties.bpm_enabled.enabled_option.bpm_system_probe_processes.value ))
     - name: datadog-bpm
       include:
-        deployments:
-          - (( ..datadog.deployment_name ))
+        stemcell: (( .properties.include_stemcell.parsed_manifest(stemcell) ))
+        deployments: (( .properties.include_deployments.parsed_manifest(deployments) ))
+        jobs: (( .properties.include_jobs.parsed_manifest(jobs) ))
+        instance_groups: (( .properties.include_instance_groups.parsed_manifest(instance_groups) ))
+        networks: (( .properties.include_networks.parsed_manifest(networks) ))
+        teams: (( .properties.include_teams.parsed_manifest(teams) ))
+        lifecycle: (( .properties.include_lifecycle.value || "" ))
+      exclude:
+        stemcell: (( .properties.exclude_stemcell.parsed_manifest(stemcell) ))
+        deployments: (( .properties.exclude_deployments.parsed_manifest(deployments) ))
+        jobs: (( .properties.exclude_jobs.parsed_manifest(jobs) ))
+        instance_groups: (( .properties.exclude_instance_groups.parsed_manifest(instance_groups) ))
+        networks: (( .properties.exclude_networks.parsed_manifest(networks) ))
+        teams: (( .properties.exclude_teams.parsed_manifest(teams) ))
+        lifecycle: (( .properties.exclude_lifecycle.value || "" ))
       jobs:
       - name: bpm
         release: bpm


### PR DESCRIPTION
<!--
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
-->

### What does this PR do?

Fixes the [placement rules](https://bosh.io/docs/runtime-config/#placement-rules) for the `datadog-bpm` job to match those of the`dd-agent` addon to ensure that bpm will always be available wherever `dd-agent` is installed.
<!-- 
What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.
-->

### Description of the Change

Matches the placement rules (include/exclude lists) between `dd-agent` job and `datadog-bpm` job.
See [Runtime Config addon](https://bosh.io/docs/runtime-config/#addons).

<!--
A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
