### PR TITLE
Remove `datadog-bpm` job and `bpm` release

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -1035,9 +1035,6 @@ forms:
       configurable: true
 
 packages:
-- name: bpm
-  type: bosh-release
-  path: resources/bpm-release.tgz
 - name: datadog-firehose-nozzle-release
   type: bosh-release
   path: resources/datadog-firehose-nozzle-release.tgz

--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -1164,8 +1164,6 @@ runtime_configs:
     releases:
     - name: datadog-agent
       version: "4.16.0"     # Update this if update the agent
-    - name: bpm
-      version: "1.2.7"      # Update this if update bpm
     addons:
     - name: datadog
       include:
@@ -1273,13 +1271,6 @@ runtime_configs:
           system_probe.memory: (( .properties.bpm_enabled.enabled_option.bpm_system_probe_memory.value || "" ))
           system_probe.open_files: (( .properties.bpm_enabled.enabled_option.bpm_system_probe_open_files.value ))
           system_probe.processes: (( .properties.bpm_enabled.enabled_option.bpm_system_probe_processes.value ))
-    - name: datadog-bpm
-      include:
-        deployments:
-          - (( ..datadog.deployment_name ))
-      jobs:
-      - name: bpm
-        release: bpm
 
 - name: datadog-agent-kube-control-plan
   runtime_config:

--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -492,7 +492,8 @@ forms:
     label: Select the desired BOSH processes manager
     default: "monit"
     description: |
-      Whether to use monit or BPM to manage the Datadog Agent processes.
+      Whether to use monit or BPM to manage the Datadog Agent processess.
+      Requires BPM to be installed.
     option_templates:
     - name: disabled_option
       select_value: "monit"


### PR DESCRIPTION
Including the `bpm-release` with the dd-agent can cause conflicts with an existing installation of BPM.
Moving forward, if the datadog agent is configured to use BPM, it will utilize the installed BPM.

Supersedes https://github.com/DataDog/datadog-cluster-monitoring-pivotal-tile/pull/115